### PR TITLE
Update CI to run .NET 9 on alpine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,6 @@ jobs:
         dotnet_version:
           - "8.0"
           - "9.0"
-        exclude:
-          - container_image: docker.io/library/alpine:latest
-            dotnet_version: "9.0"
-          - container_image: docker.io/library/alpine:edge
-            dotnet_version: "9.0"
 
     container:
       image: ${{ matrix.container_image }}


### PR DESCRIPTION
.NET 9 is now available on alpine and edge.